### PR TITLE
Wait until link dealloc to clear linksByName map; integration test passing

### DIFF
--- a/client.go
+++ b/client.go
@@ -540,6 +540,7 @@ func (s *Session) mux(remoteBegin *performBegin) {
 		case l := <-s.deallocateHandle:
 			delete(links, l.remoteHandle)
 			delete(deliveryIDByHandle, l.handle)
+			delete(linksByName, l.name)
 			handles.remove(l.handle)
 			close(l.rx) // close channel to indicate deallocation
 
@@ -653,7 +654,6 @@ func (s *Session) mux(remoteBegin *performBegin) {
 				if !linkOk {
 					break
 				}
-				delete(linksByName, body.Name) // name no longer needed
 
 				link.remoteHandle = body.Handle
 				links[link.remoteHandle] = link
@@ -1429,7 +1429,7 @@ func LinkName(name string) LinkOption {
 
 // LinkSourceCapabilities sets the source capabilities.
 func LinkSourceCapabilities(capabilities ...string) LinkOption {
-	return func (l *link) error {
+	return func(l *link) error {
 		if l.source == nil {
 			l.source = new(source)
 		}


### PR DESCRIPTION
Hi @haneev,

Here are the changes I mentioned to fix the link name check (my fault for forgetting that `linksByName` gets cleared early) and the integration test.

I ran the tests and they pass. If you pull this into your branch I'll merge your PR.

I usually squash PRs before merging so that PRs go in as a single commit. In this case I believe my change will get squashed into yours and you will end up as the author for all the changes. That's fine by me, but let me know if you have any concerns about that.

Thanks!